### PR TITLE
Check touch move direction to allow people to scroll over the slider

### DIFF
--- a/zRS.js
+++ b/zRS.js
@@ -484,7 +484,9 @@
 
 					self.on('touchmove', function(e) {
 
-						e.preventDefault();
+						if ((e.distX > e.distY && e.distX < -e.distY) || (e.distX < e.distY && e.distX > -e.distY)) {
+							e.preventDefault();
+						}
 
 					});
 


### PR DESCRIPTION
When touch is enabled. If the slider takes the whole screen up, and the user tries to scroll down, the touch binding hijacks the scroll and the user gets stuck. This checks the direction of the swipe, and if it is vertical, will scroll as normal.
